### PR TITLE
Feature/11615 livesearch view

### DIFF
--- a/lmu/policy/base/browser.py
+++ b/lmu/policy/base/browser.py
@@ -1,4 +1,10 @@
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone import PloneMessageFactory as _
+from Products.CMFPlone.browser.navtree import getNavigationRoot
+from Products.CMFPlone.utils import safe_unicode
+from Products.Five.browser import BrowserView
+from Products.PythonScripts.standard import html_quote
+from Products.PythonScripts.standard import url_quote_plus
 from plone.app.search.browser import Search as BaseSearch
 
 
@@ -21,3 +27,199 @@ class Search(BaseSearch):
     def types_list(self):
         types = super(Search, self).types_list()
         return types + self.extra_types()
+
+
+class LivesearchReply(BrowserView):
+
+    def __call__(self):
+        q = self.request.get('q', '')
+        limit = self.request.get('limit', 10)
+        path = self.request.get('path', None)
+
+        ploneUtils = getToolByName(self.context, 'plone_utils')
+        portal_url = getToolByName(self.context, 'portal_url')()
+        pretty_title_or_id = ploneUtils.pretty_title_or_id
+        plone_view = self.context.restrictedTraverse('@@plone')
+        portal_state = self.context.restrictedTraverse('@@plone_portal_state')
+
+        portalProperties = getToolByName(self.context, 'portal_properties')
+        siteProperties = getattr(portalProperties, 'site_properties', None)
+        useViewAction = []
+        if siteProperties is not None:
+            useViewAction = siteProperties.getProperty(
+                                'typesUseViewActionInListings', [])
+
+        # SIMPLE CONFIGURATION
+        USE_ICON = True
+        MAX_TITLE = 50
+        MAX_DESCRIPTION = 150
+
+        # generate a result set for the query
+        catalog = self.context.portal_catalog
+
+        friendly_types = ploneUtils.getUserFriendlyTypes()
+        if siteProperties is not None:
+            extra_types = siteProperties.getProperty('extra_types_searched', [])
+            friendly_types += extra_types
+
+        self.context.plone_log(str(friendly_types))
+
+        def quotestring(s):
+            return '"%s"' % s
+
+
+        def quote_bad_chars(s):
+            bad_chars = ["(", ")"]
+            for char in bad_chars:
+                s = s.replace(char, quotestring(char))
+            return s
+
+
+        # for now we just do a full search to prove a point, this is not the
+        # way to do this in the future, we'd use a in-memory probability based
+        # result set.
+        # convert queries to zctextindex
+
+        # XXX really if it contains + * ? or -
+        # it will not be right since the catalog ignores all non-word
+        # characters equally like
+        # so we don't even attept to make that right.
+        # But we strip these and these so that the catalog does
+        # not interpret them as metachars
+        # See http://dev.plone.org/plone/ticket/9422 for an explanation of '\u3000'
+        multispace = u'\u3000'.encode('utf-8')
+        for char in ('?', '-', '+', '*', multispace):
+            q = q.replace(char, ' ')
+        r = q.split()
+        r = " AND ".join(r)
+        r = quote_bad_chars(r) + '*'
+        searchterms = url_quote_plus(r)
+
+        REQUEST = self.context.REQUEST
+        params = {'SearchableText': r,
+                  'sort_limit': limit + 1}
+        if 'portal_type' not in REQUEST:
+            params['portal_type'] = friendly_types
+
+        if path is None:
+            pass
+        #    params['path'] = getNavigationRoot(self.context)
+        else:
+            params['path'] = path
+
+        # search limit+1 results to know if limit is exceeded
+        #self.context.plone_log(str(params))
+        pre_results = catalog(REQUEST, **params)
+
+        searchterm_query = '?searchterm=%s' % url_quote_plus(q)
+
+        RESPONSE = REQUEST.RESPONSE
+        RESPONSE.setHeader('Content-Type', 'text/xml;charset=utf-8')
+
+        # replace named entities with their numbered counterparts, in the xml the named
+        # ones are not correct
+        #   &darr;      --> &#8595;
+        #   &hellip;    --> &#8230;
+        legend_livesearch = _('legend_livesearch', default='LiveSearch &#8595;')
+        label_no_results_found = _('label_no_results_found',
+                                   default='No matching results found.')
+        label_advanced_search = _('label_advanced_search',
+                                  default='Advanced Search&#8230;')
+        label_show_all = _('label_show_all', default='Show all items')
+
+        ts = getToolByName(self.context, 'translation_service')
+
+        results = []
+
+
+        for result in pre_results:
+            self.context.plone_log(result)    
+            # Only show Fiona Content in results that are from 'sp'
+            if not result.has_key('path_string'):
+                continue
+            elif result['path_string'].startswith('/prototyp-1/sp'):
+                results.append(result)
+
+
+
+        output = []
+
+
+        def write(s):
+            output.append(safe_unicode(s))
+
+
+        if not results:
+            write('''<div class="LSIEFix">''')
+            write('''<div id="LSNothingFound">%s</div>'''
+                    % ts.translate(label_no_results_found, context=REQUEST))
+
+            write('''<ul class="LSTable">''')
+
+            write('''<li class="LSRow">''')
+            write('<a href="%s" class="advancedsearchlink">%s</a>' %
+                    (portal_url + '/search',
+                    ts.translate(label_advanced_search, context=REQUEST)))
+            write('''</li>''')
+            write('''</ul>''')
+            write('''</div>''')
+        else:
+            write('''<div class="LSIEFix">''')
+            write('''<ul class="LSTable">''')
+            for result in results[:limit]:
+                #self.context.plone_log(str(result))
+                icon = plone_view.getIcon(result)
+                itemUrl = result.getURL()
+                if result.portal_type in useViewAction:
+                    itemUrl += '/view'
+
+                itemUrl = itemUrl + searchterm_query
+
+                itemUrl = itemUrl.replace('/functions/prototyp-1/sp', '')
+
+                write('''<li class="LSRow">''')
+                write(icon.html_tag() or '')
+                #full_title = safe_unicode(pretty_title_or_id(result))
+                full_title = safe_unicode(result.Title) #get('Title','No Title set'))
+                if full_title and len(full_title) > MAX_TITLE:
+                    display_title = ''.join((full_title[:MAX_TITLE], '...'))
+                else:
+                    display_title = full_title
+
+                full_title = full_title.replace('"', '&quot;')
+                klass = 'contenttype-%s' \
+                            % ploneUtils.normalizeString(result.portal_type)
+                write('''<a href="%s" title="%s" class="%s">%s</a>'''
+                        % (itemUrl, full_title, klass, display_title))
+                display_description = safe_unicode(result.Description)
+                if display_description and len(display_description) > MAX_DESCRIPTION:
+                    display_description = ''.join(
+                        (display_description[:MAX_DESCRIPTION], '...'))
+
+                # need to quote it, to avoid injection of html containing javascript
+                # and other evil stuff
+                display_description = html_quote(display_description)
+                write('''<div class="LSDescr">%s</div>''' % (display_description))
+                write('''</li>''')
+                full_title, display_title, display_description = None, None, None
+
+            write('''<li class="LSRow">''')
+            write('<a href="%s" class="advancedsearchlink advanced-search">%s</a>' %
+                    (portal_url + '/search',
+                    ts.translate(label_advanced_search, context=REQUEST)))
+            write('''</li>''')
+
+            if len(results) > limit:
+                # add a more... row
+                write('''<li class="LSRow">''')
+                searchquery = 'search?SearchableText=%s&path=%s' \
+                                % (searchterms, params['path'])
+                write('<a href="%s" class="advancedsearchlink show-all-items">%s</a>' % (
+                                     searchquery,
+                                     ts.translate(label_show_all, context=REQUEST)))
+                write('''</li>''')
+
+            write('''</ul>''')
+            write('''</div>''')
+
+        return '\n'.join(output).encode('utf-8')

--- a/lmu/policy/base/browser.py
+++ b/lmu/policy/base/browser.py
@@ -1,6 +1,5 @@
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone import PloneMessageFactory as _
-from Products.CMFPlone.browser.navtree import getNavigationRoot
 from Products.CMFPlone.utils import safe_unicode
 from Products.Five.browser import BrowserView
 from Products.PythonScripts.standard import html_quote
@@ -38,19 +37,16 @@ class LivesearchReply(BrowserView):
 
         ploneUtils = getToolByName(self.context, 'plone_utils')
         portal_url = getToolByName(self.context, 'portal_url')()
-        pretty_title_or_id = ploneUtils.pretty_title_or_id
         plone_view = self.context.restrictedTraverse('@@plone')
-        portal_state = self.context.restrictedTraverse('@@plone_portal_state')
 
         portalProperties = getToolByName(self.context, 'portal_properties')
         siteProperties = getattr(portalProperties, 'site_properties', None)
         useViewAction = []
         if siteProperties is not None:
             useViewAction = siteProperties.getProperty(
-                                'typesUseViewActionInListings', [])
+                'typesUseViewActionInListings', [])
 
         # SIMPLE CONFIGURATION
-        USE_ICON = True
         MAX_TITLE = 50
         MAX_DESCRIPTION = 150
 
@@ -59,7 +55,8 @@ class LivesearchReply(BrowserView):
 
         friendly_types = ploneUtils.getUserFriendlyTypes()
         if siteProperties is not None:
-            extra_types = siteProperties.getProperty('extra_types_searched', [])
+            extra_types = siteProperties.getProperty(
+                'extra_types_searched', [])
             friendly_types += extra_types
 
         self.context.plone_log(str(friendly_types))
@@ -67,13 +64,11 @@ class LivesearchReply(BrowserView):
         def quotestring(s):
             return '"%s"' % s
 
-
         def quote_bad_chars(s):
             bad_chars = ["(", ")"]
             for char in bad_chars:
                 s = s.replace(char, quotestring(char))
             return s
-
 
         # for now we just do a full search to prove a point, this is not the
         # way to do this in the future, we'd use a in-memory probability based
@@ -86,7 +81,8 @@ class LivesearchReply(BrowserView):
         # so we don't even attept to make that right.
         # But we strip these and these so that the catalog does
         # not interpret them as metachars
-        # See http://dev.plone.org/plone/ticket/9422 for an explanation of '\u3000'
+        # See http://dev.plone.org/plone/ticket/9422 for an explanation of
+        # '\u3000'
         multispace = u'\u3000'.encode('utf-8')
         for char in ('?', '-', '+', '*', multispace):
             q = q.replace(char, ' ')
@@ -116,11 +112,10 @@ class LivesearchReply(BrowserView):
         RESPONSE = REQUEST.RESPONSE
         RESPONSE.setHeader('Content-Type', 'text/xml;charset=utf-8')
 
-        # replace named entities with their numbered counterparts, in the xml the named
-        # ones are not correct
+        # replace named entities with their numbered counterparts, in the xml
+        # the named ones are not correct
         #   &darr;      --> &#8595;
         #   &hellip;    --> &#8230;
-        legend_livesearch = _('legend_livesearch', default='LiveSearch &#8595;')
         label_no_results_found = _('label_no_results_found',
                                    default='No matching results found.')
         label_advanced_search = _('label_advanced_search',
@@ -131,35 +126,30 @@ class LivesearchReply(BrowserView):
 
         results = []
 
-
         for result in pre_results:
-            self.context.plone_log(result)    
+            self.context.plone_log(result)
             # Only show Fiona Content in results that are from 'sp'
-            if not result.has_key('path_string'):
+            if not 'path_string' in result:
                 continue
             elif result['path_string'].startswith('/prototyp-1/sp'):
                 results.append(result)
 
-
-
         output = []
-
 
         def write(s):
             output.append(safe_unicode(s))
 
-
         if not results:
             write('''<div class="LSIEFix">''')
             write('''<div id="LSNothingFound">%s</div>'''
-                    % ts.translate(label_no_results_found, context=REQUEST))
+                  % ts.translate(label_no_results_found, context=REQUEST))
 
             write('''<ul class="LSTable">''')
 
             write('''<li class="LSRow">''')
             write('<a href="%s" class="advancedsearchlink">%s</a>' %
-                    (portal_url + '/search',
-                    ts.translate(label_advanced_search, context=REQUEST)))
+                  (portal_url + '/search',
+                  ts.translate(label_advanced_search, context=REQUEST)))
             write('''</li>''')
             write('''</ul>''')
             write('''</div>''')
@@ -188,35 +178,40 @@ class LivesearchReply(BrowserView):
 
                 full_title = full_title.replace('"', '&quot;')
                 klass = 'contenttype-%s' \
-                            % ploneUtils.normalizeString(result.portal_type)
+                        % ploneUtils.normalizeString(result.portal_type)
                 write('''<a href="%s" title="%s" class="%s">%s</a>'''
-                        % (itemUrl, full_title, klass, display_title))
+                      % (itemUrl, full_title, klass, display_title))
                 display_description = safe_unicode(result.Description)
-                if display_description and len(display_description) > MAX_DESCRIPTION:
+                if (display_description and
+                        len(display_description) > MAX_DESCRIPTION):
                     display_description = ''.join(
                         (display_description[:MAX_DESCRIPTION], '...'))
 
-                # need to quote it, to avoid injection of html containing javascript
-                # and other evil stuff
+                # need to quote it, to avoid injection of html containing
+                # javascript and other evil stuff
                 display_description = html_quote(display_description)
-                write('''<div class="LSDescr">%s</div>''' % (display_description))
+                write('''<div class="LSDescr">%s</div>''' %
+                      (display_description))
                 write('''</li>''')
-                full_title, display_title, display_description = None, None, None
+                full_title, display_title, display_description = (
+                    None, None, None)
 
             write('''<li class="LSRow">''')
-            write('<a href="%s" class="advancedsearchlink advanced-search">%s</a>' %
-                    (portal_url + '/search',
-                    ts.translate(label_advanced_search, context=REQUEST)))
+            write('<a href="%s" class="advancedsearchlink advanced-search">'
+                  '%s</a>' %
+                  (portal_url + '/search',
+                  ts.translate(label_advanced_search, context=REQUEST)))
             write('''</li>''')
 
             if len(results) > limit:
                 # add a more... row
                 write('''<li class="LSRow">''')
                 searchquery = 'search?SearchableText=%s&path=%s' \
-                                % (searchterms, params['path'])
-                write('<a href="%s" class="advancedsearchlink show-all-items">%s</a>' % (
-                                     searchquery,
-                                     ts.translate(label_show_all, context=REQUEST)))
+                    % (searchterms, params['path'])
+                write('<a href="%s" class="advancedsearchlink show-all-items">'
+                      '%s</a>' % (
+                      searchquery,
+                      ts.translate(label_show_all, context=REQUEST)))
                 write('''</li>''')
 
             write('''</ul>''')

--- a/lmu/policy/base/configure.zcml
+++ b/lmu/policy/base/configure.zcml
@@ -14,6 +14,14 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <browser:page
+        for="*"
+        name="livesearch_reply2"
+        class=".browser.LivesearchReply"
+        permission="zope2.View"
+        layer=".interfaces.ILMUBaseThemeLayer"
+        />
+
     <include file="overrides.zcml" />
 
 </configure>

--- a/lmu/policy/base/template_overrides/Products.CMFPlone.skins.plone_ecmascript.livesearch.js
+++ b/lmu/policy/base/template_overrides/Products.CMFPlone.skins.plone_ecmascript.livesearch.js
@@ -1,0 +1,210 @@
+/*
+    Live (interactive) full text search, wired to search gadget.
+
+    Provides global: livesearch
+*/
+
+/*jslint nomen:false */
+
+var livesearch = (function () {
+
+    // Delay in milliseconds until the search starts after the last key was
+    // pressed. This keeps the number of requests to the server low.
+    var _search_delay = 400,
+        // Delay in milliseconds until the results window closes after the
+        // searchbox looses focus.
+        _hide_delay = 400,
+
+        // stores information for each searchbox on the page
+        _search_handlers = {},
+
+        // constants for better compression
+        _LSHighlight = "LSHighlight";
+
+    function _searchfactory($form, $inputnode) {
+        // returns the search functions in a dictionary.
+        // we need a factory to get a local scope for the event, this is
+        // necessary, because IE doesn't have a way to get the target of
+        // an event in a way we need it.
+        var $lastsearch = null,
+            $request = null,
+            $cache = {},
+            $$result = $form.find('div.LSResult'),
+            $querytarget = $form.attr('action').replace(
+                $form.data('action') || '@@search',
+                $$result.data('livesearch') || 'livesearch_reply'),
+            $shadow = $form.find('div.LSShadow'),
+            $path = $form.find('input[name="path"]');
+
+        function _hide() {
+            // hides the result window
+            $$result.hide();
+            $lastsearch = null;
+        }
+
+        function _hide_delayed() {
+            // hides the result window after a short delay
+            window.setTimeout(
+                'livesearch.hide("' + $form.attr('id') + '")',
+                _hide_delay);
+        }
+
+        function _show($data) {
+            // shows the result
+            $$result.show();
+            $shadow.html($data);
+        }
+
+        function _search() {
+            // does the actual search
+            if ($lastsearch === $inputnode.value) {
+                // do nothing if the input didn't change
+                return;
+            }
+            $lastsearch = $inputnode.value;
+
+            if ($request && $request.readyState < 4) {
+                // abort any pending request
+                $request.abort();
+            }
+
+            // Do nothing as long as we have less then two characters -
+            // the search results makes no sense, and it's harder on the server.
+            if ($inputnode.value.length < 2) {
+                _hide();
+                return;
+            }
+
+            var $$query = { q: $inputnode.value };
+            if ($path.length && $path[0].checked) {
+                $$query.path = $path.val();
+            }
+            // turn into a string for use as a cache key
+            $$query = jQuery.param($$query);
+
+            // check cache
+            if ($cache[$$query]) {
+                _show($cache[$$query]);
+                return;
+            }
+
+            // the search request (retrieve as text, not a document)
+            $request = jQuery.get($querytarget, $$query, function($data) {
+                // show results if there are any and cache them
+                _show($data);
+                $cache[$$query] = $data;
+            }, 'text');
+        }
+
+        function _search_delayed() {
+            // search after a small delay, used by onfocus
+            window.setTimeout(
+                'livesearch.search("' + $form.attr('id') + '")',
+                _search_delay);
+        }
+
+        return {
+            hide: _hide,
+            hide_delayed: _hide_delayed,
+            search: _search,
+            search_delayed: _search_delayed
+        };
+    }
+
+    function _keyhandlerfactory($form) {
+        // returns the key event handler functions in a dictionary.
+        // we need a factory to get a local scope for the event, this is
+        // necessary, because IE doesn't have a way to get the target of
+        // an event in a way we need it.
+        var $timeout = null,
+            $$result = $form.find('div.LSResult'),
+            $shadow = $form.find('div.LSShadow');
+
+        function _keyUp() {
+            // select the previous element
+            var $cur = $shadow.find('li.LSHighlight').removeClass(_LSHighlight),
+                $prev = $cur.prev('li');
+
+            if (!$prev.length) {
+                $prev = $shadow.find('li:last');
+            }
+            $prev.addClass(_LSHighlight);
+            return false;
+        }
+
+        function _keyDown() {
+            // select the next element
+            var $cur = $shadow.find('li.LSHighlight').removeClass(_LSHighlight),
+                $next = $cur.next('li');
+
+            if (!$next.length) {$next = $shadow.find('li:first');}
+            $next.addClass(_LSHighlight);
+            return false;
+        }
+
+        function _keyEscape() {
+            // hide results window
+            $shadow.find('li.LSHighlight').removeClass(_LSHighlight);
+            $$result.hide();
+        }
+
+        function _handler($event) {
+            // dispatch to specific functions and handle the search timer
+            window.clearTimeout($timeout);
+            switch ($event.keyCode) {
+                case 38: return _keyUp();
+                case 40: return _keyDown();
+                case 27: return _keyEscape();
+                case 37: break; // keyLeft
+                case 39: break; // keyRight
+                default:
+                    $timeout = window.setTimeout(
+                        'livesearch.search("' + $form.attr('id') + '")',
+                        _search_delay);
+            }
+        }
+
+        function _submit() {
+            // check whether a search result was selected with the keyboard
+            // and open it
+            var $target = $shadow.find('li.LSHighlight a').attr('href');
+            if (!$target) {return;}
+            window.location = $target;
+            return false;
+        }
+
+        return {
+            handler: _handler,
+            submit: _submit
+        };
+    }
+
+    function _setup(i) {
+        // add an id which is used by other functions to find the correct node
+        var $id = 'livesearch' + i,
+            $form = jQuery(this).parents('form:first'),
+            $key_handler = _keyhandlerfactory($form);
+
+        _search_handlers[$id] = _searchfactory($form, this);
+
+        $form.attr('id', $id).submit($key_handler.submit);
+        jQuery(this).attr('autocomplete','off')
+               .keydown($key_handler.handler)
+               .focus(_search_handlers[$id].search_delayed)
+               .blur(_search_handlers[$id].hide_delayed);
+    }
+
+    jQuery(function() {
+        // find all search fields and set them up
+        jQuery("#searchGadget,input.portlet-search-gadget").each(_setup);
+    });
+
+    return {
+        search: function(id) {
+            _search_handlers[id].search();
+        },
+        hide: function(id) {
+            _search_handlers[id].hide();
+        }
+    };
+}());

--- a/lmu/policy/base/template_overrides/Products.CMFPlone.skins.plone_ecmascript.livesearch.js
+++ b/lmu/policy/base/template_overrides/Products.CMFPlone.skins.plone_ecmascript.livesearch.js
@@ -31,8 +31,8 @@ var livesearch = (function () {
             $cache = {},
             $$result = $form.find('div.LSResult'),
             $querytarget = $form.attr('action').replace(
-                $form.data('action') || '@@search',
-                $$result.data('livesearch') || 'livesearch_reply'),
+                $form.data('action') || 'search',
+                $$result.data('livesearch') || 'livesearch_reply2'),
             $shadow = $form.find('div.LSShadow'),
             $path = $form.find('input[name="path"]');
 

--- a/lmu/policy/base/templates/livesearch_reply2.pt
+++ b/lmu/policy/base/templates/livesearch_reply2.pt
@@ -37,7 +37,7 @@
         <li class="LSRow">
             <a href="@@search" class="advancedsearchlink" i18n:translate="label_advanced_search" tal:attributes="href string:${context/@@plone_portal_state/portal_url}/@@search">Advanced Search&#8230;</a>
         </li>
-        <li class="LSRow" tal:condition="python:num_results > limit">
+        <li class="LSRow" tal:condition="not:view/live_results/islastpage">
             <a href="#" class="advancedsearchlink show-all-items"
                 tal:attributes="href string:search?SearchableText=${view/searchterms}&path=${request/path}" i18n:translate="label_show_all">Show all items</a>
         </li>

--- a/lmu/policy/base/templates/livesearch_reply2.pt
+++ b/lmu/policy/base/templates/livesearch_reply2.pt
@@ -1,0 +1,45 @@
+<div i18n:domain="plone" class="LSIEFix" tal:condition="not:view/live_results">
+    <div id="LSNothingFound" i18n:translate="label_no_results_found">No matching results found.</div>
+
+    <ul class="LSTable">
+
+        <li class="LSRow">
+            <a href="@@search" class="advancedsearchlink" i18n:translate="label_advanced_search" tal:attributes="href string:${context/@@plone_portal_state/portal_url}/@@search">Advanced Search&#8230;</a>
+        </li>
+    </ul>
+</div>
+
+<div i18n:domain="plone" class="LSIEFix" tal:condition="view/live_results">
+    <ul class="LSTable" tal:define="use_view_action site_properties/typesUseViewActionInListings|python:();
+                                    plone_view nocall:context/@@plone;
+                                    num_results python:len(view.live_results);
+                                    limit request/limit|nothing;
+                                    limit python:limit or 10;
+                                    searchterm_query view/searchterm_query">
+        <tal:result tal:repeat="result view/live_results">
+        <li class="LSRow"
+            tal:define="item_type result/portal_type;
+                        item_url result/getURL;
+                        item_url python:item_type in use_view_action and (item_url + '/view') or item_url;
+                        item_url python:item_url + searchterm_query;
+                        item_url python:item_url.replace('/functions/prototyp-1/sp', '');
+                        display_title python:view.display_title(result.Title());
+                        display_description python:view.display_description(result.Description());
+                        klass python:'contenttype-' + plone_view.normalizeString(item_type);
+                        ">
+            <tal:icon replace="structure python:plone_view.getIcon(result).html_tag()" />
+            <a href="#" title="" class="contenttype"
+               tal:attributes="title result/Title; href item_url; class klass"
+               tal:content="display_title" />
+            <div class="LSDescr" tal:content="display_description" />
+        </li>
+        </tal:result>
+        <li class="LSRow">
+            <a href="@@search" class="advancedsearchlink" i18n:translate="label_advanced_search" tal:attributes="href string:${context/@@plone_portal_state/portal_url}/@@search">Advanced Search&#8230;</a>
+        </li>
+        <li class="LSRow" tal:condition="python:num_results > limit">
+            <a href="#" class="advancedsearchlink show-all-items"
+                tal:attributes="href string:search?SearchableText=${view/searchterms}&path=${request/path}" i18n:translate="label_show_all">Show all items</a>
+        </li>
+    </ul>
+</div>


### PR DESCRIPTION
There is a new browser view livesearch_reply2 based on the regular search view. livesearch.js is customised to use the new browser view. The path filter ('/prototyp-1/sp') is now active in both regular search and live search.

The path filter depends on 'path_parents' being available on the non-Plone entries as well as the Plone entries. Let me know if this is not the case, then we might have to do it differently.
