### PR TITLE
Advanced cropping

### DIFF
--- a/lmu/policy/base/__init__.py
+++ b/lmu/policy/base/__init__.py
@@ -3,4 +3,4 @@ import patches
 
 patches  # flake8
 
-MESSAGE_FACTORY = MessageFactory('lmu.poliy.base')
+MESSAGE_FACTORY = MessageFactory('lmu.policy.base')

--- a/lmu/policy/base/browser/__init__.py
+++ b/lmu/policy/base/browser/__init__.py
@@ -104,14 +104,12 @@ class Search(BaseSearch):
         else:
             catalog = getToolByName(self.context, 'portal_catalog')
             try:
-                #import ipdb; ipdb.set_trace()
                 results = catalog(**query)
             except ParseError:
                 return []
         qtime = timedelta(0)
         if isinstance(results, SolrResponse) and results.responseHeader and 'QTime' in results.responseHeader:
             qtime = timedelta(milliseconds=results.responseHeader.get('QTime'))
-        #import ipdb;ipdb.set_trace()
 
         log.debug("Raw Results: %s", getattr(results, '__dict__', {}))
         results = IContentListing(results)
@@ -131,7 +129,6 @@ class Search(BaseSearch):
     def filter_query(self, query):
         query = super(Search, self).filter_query(query)
         if query:
-            #import ipdb; ipdb.set_trace()
             if query['path'] == getNavigationRoot(self.context) or query['path'] is None:
                 query['path'] = search_paths()
                 log.debug('Make general path search, request was for "%s".', getNavigationRoot(self.context))
@@ -149,7 +146,6 @@ class Search(BaseSearch):
     def breadcrumbs(self, item):
         breadcrumbs = []
         schema = 'https://'
-        #import ipdb; ipdb.set_trace()
         try:
             flare = getattr(item, 'flare', {})
             # Lookup primary Domain Name:
@@ -197,7 +193,6 @@ class Search(BaseSearch):
             log.warn('During Breadcrumb generation has happend an Attribute error, "%s" is not found', e)
         except Exception as e:
             log.warn('%s during Breadcrumb generation for UID: "%s" => %s', type(e), item.uuid(), e)
-            #import ipdb; ipdb.set_trace()
             return None
         return breadcrumbs
 
@@ -206,7 +201,6 @@ class Search(BaseSearch):
 
     def getPortalInfo(self, item):
         portal_info = None
-        #import ipdb; ipdb.set_trace()
 
         try:
             flare = getattr(item, 'flare', {})
@@ -380,7 +374,6 @@ class UserInfo(BrowserView, _IncludeMixin):
         portrait = pm.getPersonalPortrait()
         #image = Image.open(StringIO.StringIO(portrait.data))
         #self.portrait = image.resize((30, 30))
-        #import ipdb; ipdb.set_trace()
         #small_portrait, mimetype = scale_image(StringIO.StringIO(portrait.data), (30, 30))
         #self.portrait = OFSImage.Image(id=user.getUserName(), file=small_portrait, title='')
         self.portrait = portrait

--- a/lmu/policy/base/browser/configure.zcml
+++ b/lmu/policy/base/browser/configure.zcml
@@ -122,4 +122,12 @@
         permission="zope2.View"
         />
 
+    <browser:page
+        class=".content.LMUCroppingEditor"
+        for="plone.app.imagecropping.interfaces.IImageCroppingMarker"
+        name="croppingeditor"
+        layer="lmu.policy.base.interfaces.ILMUBaseThemeLayer"
+        permission="cmf.ModifyPortalContent"
+        />
+
 </configure>

--- a/lmu/policy/base/browser/configure.zcml
+++ b/lmu/policy/base/browser/configure.zcml
@@ -123,9 +123,17 @@
         />
 
     <browser:page
-        class=".content.LMUCroppingEditor"
+        class=".content.TeaserCroppingEditor"
         for="plone.app.imagecropping.interfaces.IImageCroppingMarker"
-        name="croppingeditor"
+        name="teasercroppingeditor"
+        layer="lmu.policy.base.interfaces.ILMUBaseThemeLayer"
+        permission="cmf.ModifyPortalContent"
+        />
+
+    <browser:page
+        class=".content.HardCroppingEditor"
+        for="plone.app.imagecropping.interfaces.IImageCroppingMarker"
+        name="hardcroppingeditor"
         layer="lmu.policy.base.interfaces.ILMUBaseThemeLayer"
         permission="cmf.ModifyPortalContent"
         />

--- a/lmu/policy/base/browser/content.py
+++ b/lmu/policy/base/browser/content.py
@@ -429,6 +429,8 @@ class HardCroppingEditor(CroppingEditor):
         u"that are not part of your selection will be removed permanently. "
         u"This cannot be undone!"
     )
+    # We do not want to show the "delete cropping information" button
+    show_delete = False
 
     def get_lmu_scale(self):
         """ Manually construct a pseudo-scale with free aspect ratio """

--- a/lmu/policy/base/browser/content.py
+++ b/lmu/policy/base/browser/content.py
@@ -24,6 +24,7 @@ from z3c.form.interfaces import INPUT_MODE
 from zope.annotation.interfaces import IAnnotations
 from zope.component import getMultiAdapter
 from zope.event import notify
+from zope.i18n import translate
 from zope.interface import alsoProvides
 
 from lmu.policy.base import MESSAGE_FACTORY as _  # XXX move translations
@@ -376,12 +377,28 @@ class LMUCommentsViewlet(CommentsViewlet):
         return super(LMUCommentsViewlet, self).can_reply()
 
 
-class TeaserCroppingEditor(CroppingEditor):
+class _LMUCroppingEditor(CroppingEditor):
+
+    def __call__(self):
+        plt = api.portal.get_tool('portal_languages')
+        self.lang = plt.getPreferredLanguage()
+        return super(_LMUCroppingEditor, self).__call__()
+
+    @property
+    def title(self):
+        return translate(self._title, target_language=self.lang)
+
+    @property
+    def description(self):
+        return translate(self._description, target_language=self.lang)
+
+
+class TeaserCroppingEditor(_LMUCroppingEditor):
 
     template = ViewPageTemplateFile('templates/cropping-editor.pt')
 
-    title = _(u"Choose image detail")
-    description = _(
+    _title = _(u"Choose image detail")
+    _description = _(
         u"Here you can choose a section of the image that will be shown as "
         u"teaser image on listings and overviews. The aspect ratio is forced "
         u"to 16×9. You can later on pick a different section, or remove your "
@@ -418,12 +435,12 @@ class TeaserCroppingEditor(CroppingEditor):
         )[0]
 
 
-class HardCroppingEditor(CroppingEditor):
+class HardCroppingEditor(_LMUCroppingEditor):
 
     template = ViewPageTemplateFile('templates/cropping-editor.pt')
 
-    title = _(u"Crop Image")
-    description = _(
+    _title = _(u"Crop Image")
+    _description = _(
         u"Here you can optionally crop the image, that means choose a section"
         u" of the image that you consider relevant. The parts of the image "
         u"that are not part of your selection will be removed permanently. "

--- a/lmu/policy/base/browser/templates/cropping-editor.pt
+++ b/lmu/policy/base/browser/templates/cropping-editor.pt
@@ -1,0 +1,164 @@
+<html metal:use-macro="context/main_template/macros/master"
+  xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+  xmlns:metal="http://xml.zope.org/namespaces/metal"
+  xmlns:tal="http://xml.zope.org/namespaces/tal"
+  i18n:domain="plone.app.imagecropping">
+
+  <body>
+
+    <metal:main fill-slot="main">
+      <h1 class="documentFirstHeading"
+        i18n:translate="">
+          Image Cropping Editor
+      </h1>
+
+      <tal:noScales condition="not: view/showCropping">
+        <p class="documentDescription"
+            i18n:translate="noscales_message">
+          There are no scales to crop. Make sure to add them to the
+          <a href="#" i18n:name="link" i18n:translate=""
+            tal:define="portal context/@@plone_portal_state/portal_url"
+            tal:attributes="href string:$portal/@@imagecropping-settings">
+            List of scales with crop support</a>
+          in the controlpanel.
+        </p>
+      </tal:noScales>
+
+      <tal:scales condition="view/showCropping">
+        <p class="documentDescription" i18n:translate="">
+          Here you can define cropping areas for each scale of the available imagefields.
+          This operation is non-destructive which means, your original image data doesn't get lost when cropping a scale.
+          By removing a cropping area, the scale gets back to its default functionality: resize, no crop.
+        </p>
+        <div class="row"
+             tal:define="image_field_names view/image_field_names;
+                         multiple_flds python:len(image_field_names) &gt; 1;
+                         scales view/lmu_scales;
+                         current_scale view/current_scale">
+            <div class="cell width-1:4 position-0"
+                 tal:condition="multiple_flds">
+                  <h3 i18n:translate="">Available Image Fields</h3>
+                  <ul class="fields visualNoMarker">
+                      <li class="croppingimagefield"
+                          tal:repeat="fieldname image_field_names">
+                          <a tal:define="image_url python:view.image_url(fieldname)"
+                             tal:attributes="href string:${context_state/current_base_url}?fieldname=${fieldname};
+                                             id string:selectorlink-${fieldname}"
+                             tal:omit-tag="not:image_url">
+                              <h4 tal:content="python:view.field_label(fieldname)">image field label</h4>
+                              <img style="max-width:100%;height:auto;"
+                                   tal:condition="image_url"
+                                   tal:attributes="src python:view.image_url(fieldname)" />
+                              <span class="discreet"
+                                    tal:condition="not:image_url"
+                                    i18n:translate="">
+                                  no image available
+                              </span>
+                          </a>
+                      </li>
+                  </ul>
+            </div>
+
+            <div class="cell width-1:4"
+                 tal:attributes="class python:'cell width-1:4 position-%s' % (multiple_flds and '1:4' or '0')">
+
+              <h3 i18n:translate="">Available Image Scales for Field: &quot;<span i18n:name="field_name" tal:content="python:view.field_label(view.fieldname)" tal:omit-tag="">Field Name</span>&quot;</h3>
+              <ul class="scales visualNoMarker">
+                  <li tal:repeat="scale scales"
+                      tal:attributes="data-jcrop_config scale/config;
+                                      data-scale_name scale/id;
+                                      class scale/selected">
+                      <a href="javascript:void(0)"
+                         tal:attributes="id string:imagescale_${scale/id}">
+                          <span class="scaleDesc">
+                            <span omit-tag=""
+                                  tal:content="scale/title">mini (100, 100)</span>
+                            <span omit-tag="" i18n:translate="" tal:condition="scale/is_cropped">cropped</span>
+                            <span omit-tag="" i18n:translate="" tal:condition="not: scale/is_cropped">uncropped</span>
+                          </span><br />
+                          <div class="thumbPreview"
+                               tal:attributes="id string:preview-${scale/id};
+                                               style string:width:${scale/thumb_width}px;;max-width:100%">
+                              <img tal:define="is_cropped scale/is_cropped;
+                                               src python:'%s/@@images/%s/%s' % (context.absolute_url(), view.fieldname, scale['id'])"
+                                   tal:attributes="src src" />
+                          </div>
+                      </a>
+                  </li>
+              </ul>
+            </div>
+
+            <div class="cell width-1:2 position-1:2"
+                 tal:attributes="class python:'cell width-%s position-%s' % (multiple_flds and '1:2' or '3:4', multiple_flds and '1:2' or '1:4')"
+                 tal:define="fieldname request/fieldname|view/fieldname">
+
+              <form method="post" id="coords" class="coords" tal:attributes="action context_state/current_base_url"
+                                                             tal:condition="scales">
+
+                  <!--JCrop Editor-->
+                  <img class="cropbox" tal:attributes="src python:view.image_url(fieldname);" />
+
+                  <div>
+                    <input type="hidden" size="4" id="x1" name="x1" />
+                    <input type="hidden" size="4" id="y1" name="y1" />
+                    <input type="hidden" size="4" id="x2" name="x2" />
+                    <input type="hidden" size="4" id="y2" name="y2" />
+                    <input type="hidden" id="scalename" name="scalename" value=""
+                      tal:attributes="value current_scale/id" />
+                    <input type="hidden" id="fieldname" name="fieldname" value="" tal:attributes="value fieldname" />
+
+                  </div>
+                  <input type="submit"
+                    class="context"
+                    value="Save cropping information"
+                    i18n:attributes="value"
+                    name="form.button.Save"
+                    />
+                  <div class="discreet tooltip"
+                       i18n:translate="">
+                      Save this cropping area for the selected scale.
+                  </div>
+                  <input type="submit"
+                    class="context"
+                    value="Remove cropping information"
+                    i18n:attributes="value"
+                    name="form.button.Delete"
+                    />
+                  <div class="discreet tooltip"
+                       i18n:translate="">
+                      The selected scale gets reverted to the default behaviour: resize, no crop.
+                  </div>
+                  <input type="submit"
+                    class="standalone"
+                    value="Close"
+                    tal:condition="ajax_load"
+                    i18n:attributes="value"
+                    name="form.button.Cancel"
+                    />
+
+                  <input type="hidden" name="ajax_load"
+                      tal:condition="ajax_load"
+                      tal:attributes="value ajax_load" />
+              </form>
+
+            </div>
+
+            <div class="visualClear"><!-- --></div>
+        </div>
+
+      <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/jquery.Jcrop.min.js"></script>
+      <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/cropping.js"></script>
+      <script type="application/javascript"
+              tal:content="string:
+          var imagecropping = new ImageCropping();
+          imagecropping.i18n_message_ids.confirm_discard_changes = '${view/translated_confirm_discard_changes}';
+          jQuery(function(jq) {
+             imagecropping.init_editor();
+          });"></script>
+
+    </tal:scales>
+    </metal:main>
+
+  </body>
+
+</html>

--- a/lmu/policy/base/browser/templates/cropping-editor.pt
+++ b/lmu/policy/base/browser/templates/cropping-editor.pt
@@ -4,9 +4,9 @@
   xmlns:tal="http://xml.zope.org/namespaces/tal"
   i18n:domain="plone.app.imagecropping">
 
-  <body>
-
-    <metal:main fill-slot="main">
+<body>
+  <metal:main fill-slot="main">
+    <div id="content-core">
       <h1 class="documentFirstHeading" tal:content="view/title">Title</h1>
 
       <tal:noScales condition="not: view/showCropping">
@@ -23,8 +23,9 @@
 
       <tal:scales condition="view/showCropping">
         <p class="documentDescription" tal:content="view/description">description</p>
-        <div tal:define="scale view/get_lmu_scale">
-
+        <tal:scale define="scale view/get_lmu_scale">
+          <form method="post" id="coords" class="coords" tal:attributes="action context_state/current_base_url"
+                                                             tal:condition="scale">
             <ul class="scales visualNoMarker hidden">
               <li tal:attributes="data-jcrop_config scale/config;
                                   data-scale_name scale/id;
@@ -43,12 +44,8 @@
               </li>
             </ul>
 
-
             <div class="cell width-1:2 position-1:4"
                  tal:define="fieldname request/fieldname|view/fieldname">
-
-              <form method="post" id="coords" class="coords" tal:attributes="action context_state/current_base_url"
-                                                             tal:condition="scale">
 
                   <!--JCrop Editor-->
                   <img class="cropbox" tal:attributes="src python:view.image_url(fieldname);" />
@@ -63,43 +60,38 @@
                     <input type="hidden" id="fieldname" name="fieldname" value="" tal:attributes="value fieldname" />
 
                   </div>
-                  <input type="submit"
-                    class="context"
-                    value="Save cropping information"
-                    i18n:attributes="value"
-                    name="form.button.Save"
-                    />
-                  <div class="discreet tooltip"
-                       i18n:translate="">
-                      Save this cropping area for the selected scale.
-                  </div>
-                  <input type="submit"
-                    class="context"
-                    value="Remove cropping information"
-                    i18n:attributes="value"
-                    name="form.button.Delete"
-                    />
-                  <div class="discreet tooltip"
-                       i18n:translate="">
-                      The selected scale gets reverted to the default behaviour: resize, no crop.
-                  </div>
-                  <input type="submit"
-                    class="standalone"
-                    value="Close"
-                    tal:condition="ajax_load"
-                    i18n:attributes="value"
-                    name="form.button.Cancel"
-                    />
-
-                  <input type="hidden" name="ajax_load"
-                      tal:condition="ajax_load"
-                      tal:attributes="value ajax_load" />
-              </form>
 
             </div>
 
             <div class="visualClear"><!-- --></div>
-        </div>
+            <div class="formControls">
+              <input type="submit"
+                class="context button-field"
+                value="Save cropping information"
+                i18n:attributes="value"
+                name="form.button.Save"
+                />
+              <input type="submit"
+                tal:condition="view/show_delete|string:1"
+                class="context button-field"
+                value="Remove cropping information"
+                i18n:attributes="value"
+                name="form.button.Delete"
+                />
+              <input type="submit"
+                class="standalone button-field"
+                value="Close"
+                tal:condition="ajax_load"
+                i18n:attributes="value"
+                name="form.button.Cancel"
+                />
+
+              <input type="hidden" name="ajax_load"
+                  tal:condition="ajax_load"
+                  tal:attributes="value ajax_load" />
+                  </div>
+          </form>
+        </tal:scale>
 
       <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/jquery.Jcrop.min.js"></script>
       <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/cropping.js"></script>
@@ -112,8 +104,8 @@
           });"></script>
 
     </tal:scales>
-    </metal:main>
-
-  </body>
+  </div>
+</metal:main>
+</body>
 
 </html>

--- a/lmu/policy/base/browser/templates/cropping-editor.pt
+++ b/lmu/policy/base/browser/templates/cropping-editor.pt
@@ -7,10 +7,7 @@
   <body>
 
     <metal:main fill-slot="main">
-      <h1 class="documentFirstHeading"
-        i18n:translate="">
-          Image Cropping Editor
-      </h1>
+      <h1 class="documentFirstHeading" tal:content="view/title">Title</h1>
 
       <tal:noScales condition="not: view/showCropping">
         <p class="documentDescription"
@@ -25,75 +22,33 @@
       </tal:noScales>
 
       <tal:scales condition="view/showCropping">
-        <p class="documentDescription" i18n:translate="">
-          Here you can define cropping areas for each scale of the available imagefields.
-          This operation is non-destructive which means, your original image data doesn't get lost when cropping a scale.
-          By removing a cropping area, the scale gets back to its default functionality: resize, no crop.
-        </p>
-        <div class="row"
-             tal:define="image_field_names view/image_field_names;
-                         multiple_flds python:len(image_field_names) &gt; 1;
-                         scales view/lmu_scales;
-                         current_scale view/current_scale">
-            <div class="cell width-1:4 position-0"
-                 tal:condition="multiple_flds">
-                  <h3 i18n:translate="">Available Image Fields</h3>
-                  <ul class="fields visualNoMarker">
-                      <li class="croppingimagefield"
-                          tal:repeat="fieldname image_field_names">
-                          <a tal:define="image_url python:view.image_url(fieldname)"
-                             tal:attributes="href string:${context_state/current_base_url}?fieldname=${fieldname};
-                                             id string:selectorlink-${fieldname}"
-                             tal:omit-tag="not:image_url">
-                              <h4 tal:content="python:view.field_label(fieldname)">image field label</h4>
-                              <img style="max-width:100%;height:auto;"
-                                   tal:condition="image_url"
-                                   tal:attributes="src python:view.image_url(fieldname)" />
-                              <span class="discreet"
-                                    tal:condition="not:image_url"
-                                    i18n:translate="">
-                                  no image available
-                              </span>
-                          </a>
-                      </li>
-                  </ul>
-            </div>
+        <p class="documentDescription" tal:content="view/description">description</p>
+        <div tal:define="scale view/get_lmu_scale">
 
-            <div class="cell width-1:4"
-                 tal:attributes="class python:'cell width-1:4 position-%s' % (multiple_flds and '1:4' or '0')">
+            <ul class="scales visualNoMarker hidden">
+              <li tal:attributes="data-jcrop_config scale/config;
+                                  data-scale_name scale/id;
+                                  class scale/selected">
+                  <a href="javascript:void(0)"
+                     tal:attributes="id string:imagescale_${scale/id}">
 
-              <h3 i18n:translate="">Available Image Scales for Field: &quot;<span i18n:name="field_name" tal:content="python:view.field_label(view.fieldname)" tal:omit-tag="">Field Name</span>&quot;</h3>
-              <ul class="scales visualNoMarker">
-                  <li tal:repeat="scale scales"
-                      tal:attributes="data-jcrop_config scale/config;
-                                      data-scale_name scale/id;
-                                      class scale/selected">
-                      <a href="javascript:void(0)"
-                         tal:attributes="id string:imagescale_${scale/id}">
-                          <span class="scaleDesc">
-                            <span omit-tag=""
-                                  tal:content="scale/title">mini (100, 100)</span>
-                            <span omit-tag="" i18n:translate="" tal:condition="scale/is_cropped">cropped</span>
-                            <span omit-tag="" i18n:translate="" tal:condition="not: scale/is_cropped">uncropped</span>
-                          </span><br />
-                          <div class="thumbPreview"
-                               tal:attributes="id string:preview-${scale/id};
-                                               style string:width:${scale/thumb_width}px;;max-width:100%">
-                              <img tal:define="is_cropped scale/is_cropped;
-                                               src python:'%s/@@images/%s/%s' % (context.absolute_url(), view.fieldname, scale['id'])"
-                                   tal:attributes="src src" />
-                          </div>
-                      </a>
-                  </li>
-              </ul>
-            </div>
+                      <div class="thumbPreview"
+                           tal:attributes="id string:preview-${scale/id};
+                                           style string:width:${scale/thumb_width}px;;max-width:100%">
+                          <img tal:define="is_cropped scale/is_cropped;
+                                           src python:'%s/@@images/%s/%s' % (context.absolute_url(), view.fieldname, scale['id'])"
+                               tal:attributes="src src" />
+                      </div>
+                  </a>
+              </li>
+            </ul>
 
-            <div class="cell width-1:2 position-1:2"
-                 tal:attributes="class python:'cell width-%s position-%s' % (multiple_flds and '1:2' or '3:4', multiple_flds and '1:2' or '1:4')"
+
+            <div class="cell width-1:2 position-1:4"
                  tal:define="fieldname request/fieldname|view/fieldname">
 
               <form method="post" id="coords" class="coords" tal:attributes="action context_state/current_base_url"
-                                                             tal:condition="scales">
+                                                             tal:condition="scale">
 
                   <!--JCrop Editor-->
                   <img class="cropbox" tal:attributes="src python:view.image_url(fieldname);" />
@@ -104,7 +59,7 @@
                     <input type="hidden" size="4" id="x2" name="x2" />
                     <input type="hidden" size="4" id="y2" name="y2" />
                     <input type="hidden" id="scalename" name="scalename" value=""
-                      tal:attributes="value current_scale/id" />
+                      tal:attributes="value scale/id" />
                     <input type="hidden" id="fieldname" name="fieldname" value="" tal:attributes="value fieldname" />
 
                   </div>

--- a/lmu/policy/base/browser/templates/cropping-editor.pt
+++ b/lmu/policy/base/browser/templates/cropping-editor.pt
@@ -99,7 +99,6 @@
                 jQuery(function(jq) {
                    imagecropping.init_editor();
                 });"></script>
-            <script type="application/javascript">$(document).ready( function() {alert('Proof: javascript loaded!'); });</script>
           </form>
         </tal:scale>
     </tal:scales>

--- a/lmu/policy/base/browser/templates/cropping-editor.pt
+++ b/lmu/policy/base/browser/templates/cropping-editor.pt
@@ -89,20 +89,19 @@
               <input type="hidden" name="ajax_load"
                   tal:condition="ajax_load"
                   tal:attributes="value ajax_load" />
-                  </div>
+            </div>
+            <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/jquery.Jcrop.min.js"></script>
+            <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/cropping.js"></script>
+            <script type="application/javascript"
+                    tal:content="string:
+                var imagecropping = new ImageCropping();
+                imagecropping.i18n_message_ids.confirm_discard_changes = '${view/translated_confirm_discard_changes}';
+                jQuery(function(jq) {
+                   imagecropping.init_editor();
+                });"></script>
+            <script type="application/javascript">$(document).ready( function() {alert('Proof: javascript loaded!'); });</script>
           </form>
         </tal:scale>
-
-      <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/jquery.Jcrop.min.js"></script>
-      <script type="application/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/cropping.js"></script>
-      <script type="application/javascript"
-              tal:content="string:
-          var imagecropping = new ImageCropping();
-          imagecropping.i18n_message_ids.confirm_discard_changes = '${view/translated_confirm_discard_changes}';
-          jQuery(function(jq) {
-             imagecropping.init_editor();
-          });"></script>
-
     </tal:scales>
   </div>
 </metal:main>

--- a/lmu/policy/base/browser/templates/entry_content_view.pt
+++ b/lmu/policy/base/browser/templates/entry_content_view.pt
@@ -65,6 +65,22 @@
                 onLoad: ajaxify_overlay_form
             }
         });
+        $("a[href$='@@teasercroppingeditor'].popup").prepOverlay({
+            subtype:'ajax',
+            selector:'#content-core',
+            closeselector:"input[name='form.button.Cancel']",
+            config: {
+                onLoad: ajaxify_overlay_form
+            }
+        });
+        $("a[href$='@@hardcroppingeditor'].popup").prepOverlay({
+            subtype:'ajax',
+            selector:'#content-core',
+            closeselector:"input[name='form.button.Cancel']",
+            config: {
+                onLoad: ajaxify_overlay_form
+            }
+        });
         $("a[href$='delete_confirmation'].popup").prepOverlay({
             subtype:'ajax',
             selector:'#content',
@@ -187,12 +203,12 @@
                                   </a>
                               </li>
                               <li tal:condition="repeat/item/start">
-                                  <a href="#" tal:attributes="href string:${item/absolute_url}/@@teasercroppingeditor" title="Choose image detail" i18n:attributes="title">
+                                  <a href="#" class="popup" tal:attributes="href string:${item/absolute_url}/@@teasercroppingeditor" title="Choose image detail" i18n:attributes="title">
                                     <i class="fi-crop helper-big" ></i><span class="show-for-sr" i18n:translate="">Choose image detail</span>
                                   </a>
                               </li>
                               <li>
-                                  <a href="#" tal:attributes="href string:${item/absolute_url}/@@hardcroppingeditor" title="Crop Image" i18n:attributes="title">
+                                  <a href="#" class="popup" tal:attributes="href string:${item/absolute_url}/@@hardcroppingeditor" title="Crop Image" i18n:attributes="title">
                                     <i class="fi-photo helper-big" ></i><span class="show-for-sr" i18n:translate="">Crop Image</span>
                                   </a>
                               </li>

--- a/lmu/policy/base/browser/templates/entry_content_view.pt
+++ b/lmu/policy/base/browser/templates/entry_content_view.pt
@@ -177,18 +177,23 @@
                       <div class="column small-2">
                           <ul class="inline-list right">
                               <li>
-                                  <a href="#" class="popup" tal:attributes="href string:${item/absolute_url}/@@contained_image_edit">
+                                  <a href="#" class="popup" tal:attributes="href string:${item/absolute_url}/@@contained_image_edit" title="Edit" i18n:attributes="title">
                                       <i class="fi-pencil helper-big" ></i><span class="show-for-sr" i18n:translate="">Edit</span>
                                   </a>
                               </li>
                               <li>
-                                  <a href="#" class="popup" tal:attributes="href string:${item/absolute_url}/delete_confirmation">
+                                  <a href="#" class="popup" tal:attributes="href string:${item/absolute_url}/delete_confirmation" title="Delete" i18n:attributes="title">
                                     <i class="fi-x helper-big" ></i><span class="show-for-sr" i18n:translate="">Delete</span>
                                   </a>
                               </li>
+                              <li tal:condition="repeat/item/start">
+                                  <a href="#" tal:attributes="href string:${item/absolute_url}/@@teasercroppingeditor" title="Choose image detail" i18n:attributes="title">
+                                    <i class="fi-crop helper-big" ></i><span class="show-for-sr" i18n:translate="">Choose image detail</span>
+                                  </a>
+                              </li>
                               <li>
-                                  <a href="#" tal:attributes="href string:${item/absolute_url}/@@croppingeditor">
-                                    <i class="fi-crop helper-big" ></i><span class="show-for-sr" i18n:translate="">Crop Image</span>
+                                  <a href="#" tal:attributes="href string:${item/absolute_url}/@@hardcroppingeditor" title="Crop Image" i18n:attributes="title">
+                                    <i class="fi-photo helper-big" ></i><span class="show-for-sr" i18n:translate="">Crop Image</span>
                                   </a>
                               </li>
                           </ul>

--- a/lmu/policy/base/browser/templates/entry_content_view.pt
+++ b/lmu/policy/base/browser/templates/entry_content_view.pt
@@ -45,6 +45,14 @@
             });
         }
     };
+    function ajaxify_cropping_form() {
+        ajaxify_overlay_form();
+        var imagecropping = new ImageCropping();
+        imagecropping.i18n_message_ids.confirm_discard_changes = '${view/translated_confirm_discard_changes}';
+        jQuery(function(jq) {
+           imagecropping.init_editor();
+        });
+    };
 
     function set_up_functions() {
         $("a[href$='@@contained_image_edit'].popup").prepOverlay({
@@ -70,7 +78,7 @@
             selector:'#content-core',
             closeselector:"input[name='form.button.Cancel']",
             config: {
-                onLoad: ajaxify_overlay_form
+                onLoad: ajaxify_cropping_form
             }
         });
         $("a[href$='@@hardcroppingeditor'].popup").prepOverlay({
@@ -78,7 +86,7 @@
             selector:'#content-core',
             closeselector:"input[name='form.button.Cancel']",
             config: {
-                onLoad: ajaxify_overlay_form
+                onLoad: ajaxify_cropping_form
             }
         });
         $("a[href$='delete_confirmation'].popup").prepOverlay({

--- a/lmu/policy/base/browser/templates/entry_content_view.pt
+++ b/lmu/policy/base/browser/templates/entry_content_view.pt
@@ -151,7 +151,7 @@
                   <a class="toogle button radius small right helper-margin-bottom-s inline"
                      id="image_sort_button"
                      href="@@content_sort_images_view"
-                     i18n:translate="" 
+                     i18n:translate=""
                      tal:define="images view/images;
                                  nimages python: len(images);"
                      tal:condition="python: nimages > 1">Sort Images</a>
@@ -161,8 +161,8 @@
                     <div class="row helper-border-top helper-margin-bottom-s" tal:repeat="item view/images">
                       <div class="column small-2" >
 
-                        <a class="th" role="button" aria-label="Thumbnails" 
-                           tal:attributes="href item/absolute_url;" 
+                        <a class="th" role="button" aria-label="Thumbnails"
+                           tal:attributes="href item/absolute_url;"
                            tal:on-error=" item">
 
                           <img tal:define="scales item/@@images;"
@@ -186,7 +186,7 @@
                                     <i class="fi-x helper-big" ></i><span class="show-for-sr" i18n:translate="">Delete</span>
                                   </a>
                               </li>
-                              <li tal:condition="nothing">
+                              <li>
                                   <a href="#" tal:attributes="href string:${item/absolute_url}/@@croppingeditor">
                                     <i class="fi-crop helper-big" ></i><span class="show-for-sr" i18n:translate="">Crop Image</span>
                                   </a>
@@ -209,7 +209,7 @@
                   <a class="toogle button radius small right"
                      id="file_sort_button"
                      href="@@content_sort_files_view"
-                     i18n:translate="" 
+                     i18n:translate=""
                      tal:define="files view/files;
                                  nfiles python: len(files);"
                      tal:condition="python: nfiles > 1">Sort Files</a>

--- a/lmu/policy/base/browser/utils.py
+++ b/lmu/policy/base/browser/utils.py
@@ -70,7 +70,6 @@ class _IncludeMixin(object):
             REQUEST.environ['HTTP_X_THEME_DISABLED'] = True
 
             alsoProvides(REQUEST, IDisableCSRFProtection)
-            # import ipdb; ipdb.set_trace()
 
         return self.template()
 

--- a/lmu/policy/base/content.py
+++ b/lmu/policy/base/content.py
@@ -15,9 +15,6 @@ class LMUBaseContent(Container):
             return conversation.total_comments
 
     def images(self):
-        #image_brains = api.content.find(context=self.context, depth=1, portal_type='Image')
-        #images = [item.getObject() for item in image_brains]
-        #import ipdb; ipdb.set_trace()
         images = [item for item in self.values()if item.portal_type == 'Image']
         if None in images:
             images.remove(None)
@@ -27,5 +24,4 @@ class LMUBaseContent(Container):
         files = [item for item in self.values() if item.portal_type == 'File']
         if None in files:
             files.remove(None)
-        #import ipdb; ipdb.set_trace()
         return files

--- a/lmu/policy/base/css/search.css
+++ b/lmu/policy/base/css/search.css
@@ -17,3 +17,7 @@
 .searchPage #searchfields {
     overflow: visible;
 }
+
+.hidden {
+    display: none;
+}

--- a/lmu/policy/base/locales/de/LC_MESSAGES/lmu.policy.base.po
+++ b/lmu/policy/base/locales/de/LC_MESSAGES/lmu.policy.base.po
@@ -14,52 +14,86 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: DOMAIN\n"
 
+#: ./controlpanel.py:46
+msgid "1 day"
+msgstr ""
+
+#: ./controlpanel.py:49
+msgid "1 month"
+msgstr ""
+
+#: ./controlpanel.py:47
+msgid "1 week"
+msgstr ""
+
+#: ./controlpanel.py:48
+msgid "2 weeks"
+msgstr ""
+
+#: ./controlpanel.py:50
+msgid "3 month"
+msgstr ""
+
+#: ./controlpanel.py:51
+msgid "6 month"
+msgstr ""
+
 #: ./profiles/default/propertiestool.xml
 msgid "Blog Entry"
 msgstr "Blog-Beitrag"
 
-#: ./controlpanel.py:78
+#: ./controlpanel.py:89
 msgid "Breadcrumb override level 1 - Link"
 msgstr ""
 
-#: ./controlpanel.py:70
+#: ./controlpanel.py:81
 msgid "Breadcrumb override level 1 - Title"
 msgstr ""
 
-#: ./controlpanel.py:98
+#: ./controlpanel.py:109
 msgid "Breadcrumb override level 2 - Link"
 msgstr ""
 
-#: ./controlpanel.py:90
+#: ./controlpanel.py:101
 msgid "Breadcrumb override level 2 - Title"
 msgstr ""
 
-#: ./controlpanel.py:121
+#: ./controlpanel.py:132
 msgid "CMS System"
 msgstr "CMS-System"
 
-#: ./browser/templates/entry_content_view.pt:191
+#: ./browser/content.py:400
+#: ./browser/templates/entry_content_view.pt:190
+msgid "Choose image detail"
+msgstr "Bildausschnitt wählen"
+
+#: ./browser/content.py:442
+#: ./browser/templates/entry_content_view.pt:195
 msgid "Crop Image"
-msgstr "Bild bescheiden"
+msgstr "Bild beschneiden"
 
 #: ./browser/templates/entry_content_view.pt:146
 msgid "Das erste Bild wird auf den Uebersichtsseiten und gross im"
 msgstr "Das erste Bild wird auf den Übersichtsseiten und groß im"
 
-#: ./browser/templates/entry_content_view.pt:186
+#: ./browser/templates/entry_content_view.pt:185
 #: ./template_overrides/Products.CMFPlone.skins.plone_forms.delete_confirmation_page.cpt:58
 msgid "Delete"
 msgstr "Löschen"
+
+#: ./controlpanel.py:139
+msgid "Delete Timedelta"
+msgstr ""
 
 #: ./profiles/default/propertiestool.xml
 msgid "Document"
 msgstr "Dokument"
 
-#: ./controlpanel.py:109
+#: ./controlpanel.py:120
 msgid "Domain(s)"
 msgstr "Domain(s)"
 
-#: ./controlpanel.py:110
+#: ./controlpanel.py:121
 msgid "Domain(s) that the content of this site is valid for"
 msgstr "Domain(s) für welche der Inhalt dieses Portals gültig ist"
 
@@ -67,7 +101,7 @@ msgstr "Domain(s) für welche der Inhalt dieses Portals gültig ist"
 msgid "Done"
 msgstr "Fertig"
 
-#: ./browser/templates/entry_content_view.pt:181
+#: ./browser/templates/entry_content_view.pt:180
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -75,13 +109,21 @@ msgstr "Bearbeiten"
 msgid "File"
 msgstr "Datei"
 
-#: ./browser/templates/entry_content_view.pt:216
+#: ./browser/templates/entry_content_view.pt:221
 msgid "Files"
 msgstr "Dateien"
 
 #: ./profiles/default/propertiestool.xml
 msgid "Folder"
 msgstr "Ordner"
+
+#: ./browser/content.py:401
+msgid "Here you can choose a section of the image that will be shown as teaser image on listings and overviews. The aspect ratio is forced to 16×9. You can later on pick a different section, or remove your selection completely to revert to the default."
+msgstr "Hier können Sie einen Bildausschnitt wählen, der als Teaser-Bild in Auflistungen und Übersichtsseiten auftaucht. Das Seitenverhältnis ist auf 16×9 beschränkt. Sie können die getroffene Auswahl jederzeit ändern oder ganz entfernen."
+
+#: ./browser/content.py:443
+msgid "Here you can optionally crop the image, that means choose a section of the image that you consider relevant. The parts of the image that are not part of your selection will be removed permanently. This cannot be undone!"
+msgstr "Hier können Sie falls nötig das Bild zuschneiden, das heisst einen beliebigen Ausschnitt des Bildes wähen, den Sie für relevant halten. Der nicht in der Auswahl enthaltene Teil des Bildes wird entfernt. Dieser Vorgang kann nicht rückgängig gemacht werden!"
 
 #: ./browser/templates/entry_content_view.pt:158
 msgid "Images"
@@ -91,11 +133,11 @@ msgstr "Bilder"
 msgid "LMU Settings"
 msgstr "LMU Einstellungen"
 
-#: ./controlpanel.py:46
+#: ./controlpanel.py:57
 msgid "Language"
 msgstr "Sprache"
 
-#: ./controlpanel.py:122
+#: ./controlpanel.py:133
 msgid "Name that this CMS system uses to be identified among others that may be used in parallel"
 msgstr "Name des CMS-Systems, wird genutzt um das Backend System zu indentifizieren, für die Suche"
 
@@ -103,11 +145,11 @@ msgstr "Name des CMS-Systems, wird genutzt um das Backend System zu indentifizie
 msgid "No ${DYNAMIC_CONTENT} Uploaded"
 msgstr "Keine ${DYNAMIC_CONTENT} hochgeladen"
 
-#: ./browser/templates/entry_content_view.pt:244
+#: ./browser/templates/entry_content_view.pt:249
 msgid "No Files Uploaded"
 msgstr "Keine Dateien hochgeladen"
 
-#: ./browser/templates/entry_content_view.pt:203
+#: ./browser/templates/entry_content_view.pt:208
 msgid "No Images Uploaded"
 msgstr "Keine Bilder hochgeladen"
 
@@ -127,7 +169,7 @@ msgstr "Veröffentlichung"
 msgid "Search"
 msgstr "Suche"
 
-#: ./controlpanel.py:115
+#: ./controlpanel.py:126
 msgid "Search Path(s)"
 msgstr "Such-Pfade"
 
@@ -143,15 +185,15 @@ msgstr "Suchergebnisse für ${term}"
 msgid "Show Blog Rules"
 msgstr "Zu den Blog-Regeln"
 
-#: ./controlpanel.py:83
+#: ./controlpanel.py:94
 msgid "Show Breadcrumb override level 1"
 msgstr "Zeige 'Breadcrumb' Überschreiber für Level 1"
 
-#: ./controlpanel.py:103
+#: ./controlpanel.py:114
 msgid "Show Breadcrumb override level 2"
 msgstr "Zeige 'Breadcrumb' Überschreiber für Level 2"
 
-#: ./controlpanel.py:116
+#: ./controlpanel.py:127
 msgid "Solr Path_parrents that should be searched"
 msgstr "Solr Pfade die durchsucht werden sollen"
 
@@ -159,7 +201,7 @@ msgstr "Solr Pfade die durchsucht werden sollen"
 msgid "Sort"
 msgstr "Sortieren"
 
-#: ./browser/templates/entry_content_view.pt:209
+#: ./browser/templates/entry_content_view.pt:214
 msgid "Sort Files"
 msgstr "Dateien sortieren"
 
@@ -167,13 +209,17 @@ msgstr "Dateien sortieren"
 msgid "Sort Images"
 msgstr "Bilder sortieren"
 
-#: ./controlpanel.py:49
+#: ./controlpanel.py:60
 msgid "Title"
 msgstr "Titel"
 
 #: ./browser/templates/entry_content_view.pt:133
 msgid "Upload Images and Files"
 msgstr "Bilder und Dateien hochladen"
+
+#: ./controlpanel.py:140
+msgid "When sould expired Entries be deleted automaticaly"
+msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
 #: ./template_overrides/Products.CMFPlone.skins.plone_forms.delete_confirmation_page.cpt:18
@@ -206,12 +252,12 @@ msgid "batch_x_items_matching_your_criteria"
 msgstr "${number} Inhalte gefunden."
 
 #. Default: "last modified"
-#: ./browser/templates/search.pt:240
+#: ./browser/templates/search.pt:248
 msgid "box_last_modified"
 msgstr "zuletzt verändert"
 
 #. Default: "published"
-#: ./browser/templates/search.pt:230
+#: ./browser/templates/search.pt:238
 msgid "box_published"
 msgstr "Veröffentlicht"
 
@@ -228,13 +274,17 @@ msgstr "Keine Inhalte gefunden"
 msgid "down"
 msgstr "runter"
 
-#: ./browser/templates/search.pt:255
+#: ./browser/templates/search.pt:263
 msgid "filed under:"
 msgstr "Keywords"
 
 #: ./profiles/default/propertiestool.xml
 msgid "generic"
 msgstr "Dokumente, Dateien und Bilder"
+
+#: ./controlpanel.py:45
+msgid "immediat"
+msgstr ""
 
 #. Default: "Advanced Search…"
 #: ./template_overrides/Products.CMFPlone.skins.plone_scripts.livesearch_reply.py:104
@@ -243,7 +293,7 @@ msgid "label_advanced_search"
 msgstr "Erweiterte Suche"
 
 #. Default: "by ${author}"
-#: ./browser/templates/search.pt:215
+#: ./browser/templates/search.pt:222
 msgid "label_by_author"
 msgstr "Autor: ${author}"
 
@@ -382,11 +432,11 @@ msgstr "Task"
 msgid "zuv_weiterbildung"
 msgstr "Weiterbildungsangebot"
 
-#: ./browser/content.py:154
+#: ./browser/content.py:170
 msgid "Überschrift 1"
 msgstr "Überschrift 1"
 
-#: ./browser/content.py:155
+#: ./browser/content.py:171
 msgid "Überschrift 2"
 msgstr "Überschrift 2"
 

--- a/lmu/policy/base/locales/lmu.policy.base.pot
+++ b/lmu/policy/base/locales/lmu.policy.base.pot
@@ -4,7 +4,7 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
-"POT-Creation-Date: 2015-12-07 17:59+0000\n"
+"POT-Creation-Date: 2016-03-15 17:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI +ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,36 +17,66 @@ msgstr ""
 "Preferred-Encodings: utf-8 latin1\n"
 "Domain: manual\n"
 
-#: ./browser/content.py:242
-#: ./controlpanel.py:71
+#: ./browser/content.py:261
+#: ./controlpanel.py:82
 msgid ""
+msgstr ""
+
+#: ./controlpanel.py:46
+msgid "1 day"
+msgstr ""
+
+#: ./controlpanel.py:49
+msgid "1 month"
+msgstr ""
+
+#: ./controlpanel.py:47
+msgid "1 week"
+msgstr ""
+
+#: ./controlpanel.py:48
+msgid "2 weeks"
+msgstr ""
+
+#: ./controlpanel.py:50
+msgid "3 month"
+msgstr ""
+
+#: ./controlpanel.py:51
+msgid "6 month"
 msgstr ""
 
 #: ./profiles/default/propertiestool.xml
 msgid "Blog Entry"
 msgstr ""
 
-#: ./controlpanel.py:78
+#: ./controlpanel.py:89
 msgid "Breadcrumb override level 1 - Link"
 msgstr ""
 
-#: ./controlpanel.py:70
+#: ./controlpanel.py:81
 msgid "Breadcrumb override level 1 - Title"
 msgstr ""
 
-#: ./controlpanel.py:98
+#: ./controlpanel.py:109
 msgid "Breadcrumb override level 2 - Link"
 msgstr ""
 
-#: ./controlpanel.py:90
+#: ./controlpanel.py:101
 msgid "Breadcrumb override level 2 - Title"
 msgstr ""
 
-#: ./controlpanel.py:121
+#: ./controlpanel.py:132
 msgid "CMS System"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:191
+#: ./browser/content.py:400
+#: ./browser/templates/entry_content_view.pt:190
+msgid "Choose image detail"
+msgstr ""
+
+#: ./browser/content.py:442
+#: ./browser/templates/entry_content_view.pt:195
 msgid "Crop Image"
 msgstr ""
 
@@ -54,20 +84,24 @@ msgstr ""
 msgid "Das erste Bild wird auf den Uebersichtsseiten und gross im"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:186
+#: ./browser/templates/entry_content_view.pt:185
 #: ./template_overrides/Products.CMFPlone.skins.plone_forms.delete_confirmation_page.cpt:58
 msgid "Delete"
+msgstr ""
+
+#: ./controlpanel.py:139
+msgid "Delete Timedelta"
 msgstr ""
 
 #: ./profiles/default/propertiestool.xml
 msgid "Document"
 msgstr ""
 
-#: ./controlpanel.py:109
+#: ./controlpanel.py:120
 msgid "Domain(s)"
 msgstr ""
 
-#: ./controlpanel.py:110
+#: ./controlpanel.py:121
 msgid "Domain(s) that the content of this site is valid for"
 msgstr ""
 
@@ -75,7 +109,7 @@ msgstr ""
 msgid "Done"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:181
+#: ./browser/templates/entry_content_view.pt:180
 msgid "Edit"
 msgstr ""
 
@@ -83,12 +117,20 @@ msgstr ""
 msgid "File"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:216
+#: ./browser/templates/entry_content_view.pt:221
 msgid "Files"
 msgstr ""
 
 #: ./profiles/default/propertiestool.xml
 msgid "Folder"
+msgstr ""
+
+#: ./browser/content.py:401
+msgid "Here you can choose a section of the image that will be shown as teaser image on listings and overviews. The aspect ratio is forced to 16×9. You can later on pick a different section, or remove your selection completely to revert to the default."
+msgstr ""
+
+#: ./browser/content.py:443
+msgid "Here you can optionally crop the image, that means choose a section of the image that you consider relevant. The parts of the image that are not part of your selection will be removed permanently. This cannot be undone!"
 msgstr ""
 
 #: ./browser/templates/entry_content_view.pt:158
@@ -99,11 +141,11 @@ msgstr ""
 msgid "LMU Settings"
 msgstr ""
 
-#: ./controlpanel.py:46
+#: ./controlpanel.py:57
 msgid "Language"
 msgstr ""
 
-#: ./controlpanel.py:122
+#: ./controlpanel.py:133
 msgid "Name that this CMS system uses to be identified among others that may be used in parallel"
 msgstr ""
 
@@ -111,11 +153,11 @@ msgstr ""
 msgid "No ${DYNAMIC_CONTENT} Uploaded"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:244
+#: ./browser/templates/entry_content_view.pt:249
 msgid "No Files Uploaded"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:203
+#: ./browser/templates/entry_content_view.pt:208
 msgid "No Images Uploaded"
 msgstr ""
 
@@ -135,7 +177,7 @@ msgstr ""
 msgid "Search"
 msgstr ""
 
-#: ./controlpanel.py:115
+#: ./controlpanel.py:126
 msgid "Search Path(s)"
 msgstr ""
 
@@ -151,15 +193,15 @@ msgstr ""
 msgid "Show Blog Rules"
 msgstr ""
 
-#: ./controlpanel.py:83
+#: ./controlpanel.py:94
 msgid "Show Breadcrumb override level 1"
 msgstr ""
 
-#: ./controlpanel.py:103
+#: ./controlpanel.py:114
 msgid "Show Breadcrumb override level 2"
 msgstr ""
 
-#: ./controlpanel.py:116
+#: ./controlpanel.py:127
 msgid "Solr Path_parrents that should be searched"
 msgstr ""
 
@@ -167,7 +209,7 @@ msgstr ""
 msgid "Sort"
 msgstr ""
 
-#: ./browser/templates/entry_content_view.pt:209
+#: ./browser/templates/entry_content_view.pt:214
 msgid "Sort Files"
 msgstr ""
 
@@ -175,12 +217,16 @@ msgstr ""
 msgid "Sort Images"
 msgstr ""
 
-#: ./controlpanel.py:49
+#: ./controlpanel.py:60
 msgid "Title"
 msgstr ""
 
 #: ./browser/templates/entry_content_view.pt:133
 msgid "Upload Images and Files"
+msgstr ""
+
+#: ./controlpanel.py:140
+msgid "When sould expired Entries be deleted automaticaly"
 msgstr ""
 
 #. Default: "This item can not be deleted because it is currently locked by another user."
@@ -214,12 +260,12 @@ msgid "batch_x_items_matching_your_criteria"
 msgstr ""
 
 #. Default: "last modified"
-#: ./browser/templates/search.pt:240
+#: ./browser/templates/search.pt:248
 msgid "box_last_modified"
 msgstr ""
 
 #. Default: "published"
-#: ./browser/templates/search.pt:230
+#: ./browser/templates/search.pt:238
 msgid "box_published"
 msgstr ""
 
@@ -236,12 +282,16 @@ msgstr ""
 msgid "down"
 msgstr ""
 
-#: ./browser/templates/search.pt:255
+#: ./browser/templates/search.pt:263
 msgid "filed under:"
 msgstr ""
 
 #: ./profiles/default/propertiestool.xml
 msgid "generic"
+msgstr ""
+
+#: ./controlpanel.py:45
+msgid "immediat"
 msgstr ""
 
 #. Default: "Advanced Search…"
@@ -251,7 +301,7 @@ msgid "label_advanced_search"
 msgstr ""
 
 #. Default: "by ${author}"
-#: ./browser/templates/search.pt:215
+#: ./browser/templates/search.pt:222
 msgid "label_by_author"
 msgstr ""
 
@@ -390,11 +440,11 @@ msgstr ""
 msgid "zuv_weiterbildung"
 msgstr ""
 
-#: ./browser/content.py:154
+#: ./browser/content.py:170
 msgid "Überschrift 1"
 msgstr ""
 
-#: ./browser/content.py:155
+#: ./browser/content.py:171
 msgid "Überschrift 2"
 msgstr ""
 

--- a/lmu/policy/base/patches/collective_solr_flare_PloneFlare_getURL_patch.py
+++ b/lmu/policy/base/patches/collective_solr_flare_PloneFlare_getURL_patch.py
@@ -15,7 +15,6 @@ def getURL(self, relative=False):
 
     try:
         url = self.request.physicalPathToURL(path, relative)
-        #import ipdb; ipdb.set_trace()
         domain = self.get('domain')[0]
 
         if self.get('cms_system') != cms_system() or domain != portal_domains()[0]:

--- a/lmu/policy/base/profiles/default/registry.xml
+++ b/lmu/policy/base/profiles/default/registry.xml
@@ -1,4 +1,28 @@
 <?xml version="1.0"?>
 <registry>
     <records interface="lmu.policy.base.controlpanel.ILMUSettings" />
+  <record name="plone.app.imagecropping.browser.settings.ISettings.constrain_cropping" interface="plone.app.imagecropping.browser.settings.ISettings" field="constrain_cropping">
+    <field type="plone.registry.field.Bool">
+      <default>False</default>
+      <description xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone.app.imagecropping" ns0:translate="">Enable to reduce the scales shown for cropping in the list of scales with crop support.</description>
+      <required>False</required>
+      <title xmlns:ns0="http://xml.zope.org/namespaces/i18n" ns0:domain="plone.app.imagecropping" ns0:translate="">Enable to constrain cropable scales</title>
+    </field>
+    <value>True</value>
+  </record>
+  <record name="plone.app.imagecropping.browser.settings.ISettings.cropping_for" interface="plone.app.imagecropping.browser.settings.ISettings" field="cropping_for">
+    <field type="plone.registry.field.List">
+      <default/>
+      <description>Select the scales with cropping support enabled. Only active if enabled with checkbox.</description>
+      <required>False</required>
+      <title>List of scales with crop support</title>
+      <value_type type="plone.registry.field.Choice">
+        <vocabulary>plone.app.imagecropping.all_sizes</vocabulary>
+      </value_type>
+    </field>
+    <value>
+      <element>entry_teaser</element>
+      <element>listing_teaser</element>
+    </value>
+  </record>
 </registry>

--- a/lmu/policy/base/setuphandlers.py
+++ b/lmu/policy/base/setuphandlers.py
@@ -2,8 +2,8 @@ import logging
 import transaction
 
 from plone import api
-#from Products.PlonePAS.Extensions.Install import activatePluginInterface
-from Products.AutoRoleFromHostHeader.plugins.AutoRole import AutoRole
+# from Products.PlonePAS.Extensions.Install import activatePluginInterface
+# from Products.AutoRoleFromHostHeader.plugins.AutoRole import AutoRole
 
 log = logging.getLogger(__name__)
 
@@ -61,7 +61,6 @@ def _setupGroups(context):
 #def _setupAutoRoleHeader(context):
 #    acl_users = api.portal.get_tool('acl_users')
 #
-#    #import ipdb; ipdb.set_trace()
 #
 #    arh_cmsadmins = AutoRole('auto_role_header_cms-admins-insp',
 #                             title='AutoRole for CMS-Admins INSP',


### PR DESCRIPTION
Es werden 2 neue views registriert:

**hardcroppingeditor**
-  Ermöglicht, in frei wählbarer Aspect-Ration ein Bild (permanent) zu beschneiden
-  Verfügbar für alle Bilder im Blog

**teasercroppingeditor**
-  Ermöglicht, einen Ausschnitt gleichzeitig für alle Teaser-Scales festzulegen
-  Verfügbar für das erste Bild im Blog

Beide Views verweden die Editor-View von p.a.imagecropping, jeweils mit Modifikationen bei der Auswahl der Scales bzw dem Speichern des gecroppten Bilds.
