### PR TITLE
Fix js calls

### DIFF
--- a/lmu/policy/base/browser/templates/entry_content_view.pt
+++ b/lmu/policy/base/browser/templates/entry_content_view.pt
@@ -8,10 +8,13 @@
       tal:omit-tag="omit" >
 
 <tal:cropping tal:condition="images"
-              tal:define="images view/images;"
+              tal:define="
+                images view/images;
+                portal_url here/portal_url;
+              "
 >
-  <script type="text/javascript" tal:attributes="src string:/++resource++plone.app.imagecropping.static/jquery.Jcrop.min.js"></script>
-  <script type="text/javascript" tal:attributes="src string:/++resource++plone.app.imagecropping.static/cropping.js"></script>
+  <script type="text/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/jquery.Jcrop.min.js"></script>
+  <script type="text/javascript" tal:attributes="src string:${portal_url}/++resource++plone.app.imagecropping.static/cropping.js"></script>
   <script type="text/javascript"
           tal:define="
             first_image python:images[0];
@@ -148,7 +151,6 @@
           });
       }
       $(function() {
-          $.ajax({cache: false});
           $.ajaxSetup({cache: false});
 
           set_up_functions();


### PR DESCRIPTION
Prepending `${portal_url}` grants better caching.
`$.ajax({cache: false})` actually calls again the edit view and this may result in `ConflictErrors`:
```
2018-04-18 14:44:34 ERROR ZODB.ConflictResolution Unexpected error
Traceback (most recent call last):
  File "/home/ale/.buildout/eggs/ZODB3-3.10.7-py2.7-linux-x86_64.egg/ZODB/ConflictResolution.py", line 251, in tryToResolveConflict
    resolved = resolve(old, committed, newstate)
  File "/home/ale/.buildout/eggs/plone.scale-1.5.0-py2.7.egg/plone/scale/storage.py", line 81, in _p_resolveConflict
    self.raise_conflict(saved[key], new[key])
KeyError: '81841fbf-d591-41ea-83b6-68088f733a85'
2018-04-18 14:44:34 INFO ZPublisher.Conflict ConflictError at /30_zentralbereich/30zb_zuv-intranet/blog-mit/wunschbaum-aktion-1/edit: database conflict error (oid 0x022806, class plone.scale.storage.ScalesDict, serial this txn started with 0x03c6f0bc350a6abb 2018-04-18 12:44:12.431412, serial currently committed 0x03c6f0bc928ca477 2018-04-18 12:44:34.347512) (1 conflicts (0 unresolved) since startup at Wed Apr 18 14:44:25 2018)
```